### PR TITLE
Update function list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The current list of functions and associated files is below:
 | Forcepoint_DLP_Information | Returns Forcepoint Data Loss Prevention config, if present | /Library/Application Support/Websense Endpoint/DLP/DLPClient.plist | 
 | Krb5_AD_Config | Returns Kerberos/AD config information, if present | /etc/krb5.conf | 
 | Krb5_AD_Logging | Returns Kerberos logging configuration, if present | /Library/Preferences/com.apple.Kerberos.plist | 
+| PaloaltoGlobalProtect | Returns Palo Alto Networks GlobalProtect config, if present | /Library/Preferences/com.paloaltonetworks.GlobalProtect.settings.plist | 
 | All_Checks | Do all of the above checks | |
 | User_Preferences | Do all checks related to the user specifically | |
 | Global_Preferences | Do all checks related to global preferences that don't fall in ~/ | |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The current list of functions and associated files is below:
 | Bluetooth_Connections | List of bluetooth connections, when they last connected, and what class of item/name |/Library/Preferences/com.apple.Bluetooth.plist | 
 | OS_Version | Software build version, name, and normal version | /System/Library/CoreServices/SystemVersion.plist|
 | Forcepoint_DLP_Information | Returns Forcepoint Data Loss Prevention config, if present | /Library/Application Support/Websense Endpoint/DLP/DLPClient.plist | 
+| Krb5_AD_Config | Returns Kerberos/AD config information, if present | /etc/krb5.conf | 
 | All_Checks | Do all of the above checks | |
 | User_Preferences | Do all checks related to the user specifically | |
 | Global_Preferences | Do all checks related to global preferences that don't fall in ~/ | |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The current list of functions and associated files is below:
 | Network_Interfaces | List of basic network interfaces, active, type, and user information | /Library/Preferences/SystemConfiguration/NetworkInterfaces.plist| 
 | Bluetooth_Connections | List of bluetooth connections, when they last connected, and what class of item/name |/Library/Preferences/com.apple.Bluetooth.plist | 
 | OS_Version | Software build version, name, and normal version | /System/Library/CoreServices/SystemVersion.plist|
+| Forcepoint_DLP_Information | Returns Forcepoint Data Loss Prevention config, if present | /Library/Application Support/Websense Endpoint/DLP/DLPClient.plist | 
 | All_Checks | Do all of the above checks | |
 | User_Preferences | Do all checks related to the user specifically | |
 | Global_Preferences | Do all checks related to global preferences that don't fall in ~/ | |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ The current list of functions and associated files is below:
 | WiFi_Messages | List of WiFi association SSIDs | /Library/Preferences/SystemConfiguration/com.apple.wifi.message-tracer.plist| 
 | Network_Interfaces | List of basic network interfaces, active, type, and user information | /Library/Preferences/SystemConfiguration/NetworkInterfaces.plist| 
 | Bluetooth_Connections | List of bluetooth connections, when they last connected, and what class of item/name |/Library/Preferences/com.apple.Bluetooth.plist | 
-| Jamf_Information | List of Jamf configuration details and Azure information (if applicable) |/Library/Preferences/com.jamfsoftware.jamf.plist | 
 | OS_Version | Software build version, name, and normal version | /System/Library/CoreServices/SystemVersion.plist|
 | All_Checks | Do all of the above checks | |
 | User_Preferences | Do all checks related to the user specifically | |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The current list of functions and associated files is below:
 | OS_Version | Software build version, name, and normal version | /System/Library/CoreServices/SystemVersion.plist|
 | Forcepoint_DLP_Information | Returns Forcepoint Data Loss Prevention config, if present | /Library/Application Support/Websense Endpoint/DLP/DLPClient.plist | 
 | Krb5_AD_Config | Returns Kerberos/AD config information, if present | /etc/krb5.conf | 
+| Krb5_AD_Logging | Returns Kerberos logging configuration, if present | /Library/Preferences/com.apple.Kerberos.plist | 
 | All_Checks | Do all of the above checks | |
 | User_Preferences | Do all checks related to the user specifically | |
 | Global_Preferences | Do all checks related to global preferences that don't fall in ~/ | |


### PR DESCRIPTION
These commits remove one command from the list that doesn't appear to be around anymore (`Jamf_Information()`) and add some functions that weren't documented yet. I can also alphabetize the list to make these easier to spot next time.

What do you think about changing the `Plist` column header to `Source`, since some of the config files aren't PLISTs? 👍 / 👎 

Thanks for working on this and sharing it! 🤝 