### PR TITLE
Fix AVEnum() output for Do Not Disturb.app

### DIFF
--- a/HealthInspector.js
+++ b/HealthInspector.js
@@ -1159,7 +1159,7 @@ function AVEnum() {
 	}
 
 	if ((allapps.includes("dnd")) || (fileMan.fileExistsAtPath("/Library/Objective-See/DND")) || (fileMan.fileExistsAtPath("/Applications/Do Not Disturb.app/"))){
-	        output += "[+] LuLu firewall found.\n";
+	        output += "[+] Do Not Disturb 'lid open' event monitor found.\n";
 	        b = 1;
 	}
 


### PR DESCRIPTION
Was indicating that the LuLu firewall was installed instead